### PR TITLE
Implement Wasm control flow operators

### DIFF
--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -31,3 +31,5 @@ discriminants
 implementer/S
 formatter
 representable
+Cranelift
+preallocate

--- a/.config/cargo_spellcheck.dic
+++ b/.config/cargo_spellcheck.dic
@@ -33,3 +33,4 @@ formatter
 representable
 Cranelift
 preallocate
+reachability

--- a/crates/module/src/func_body/builder.rs
+++ b/crates/module/src/func_body/builder.rs
@@ -441,6 +441,11 @@ impl<'a> FunctionBuilder<'a> {
         Ok(value)
     }
 
+    /// Returns the block parameters of the given block.
+    pub fn block_parameters(&self, block: Block) -> &[Value] {
+        &self.ctx.block_params[block]
+    }
+
     /// Creates a new incomplete block parameter.
     ///
     /// These block parameters are driven by the SSA value construction
@@ -824,6 +829,15 @@ impl<'a> FunctionBuilder<'a> {
     /// - If the variable has not been declared.
     pub fn var_type(&mut self, var: Variable) -> Result<Type, Error> {
         Ok(self.ctx.vars.get(var)?.ty())
+    }
+
+    /// Returns the type of the given value.
+    ///
+    /// # Panics
+    ///
+    /// If the given value is invalid.
+    pub fn value_type(&self, value: Value) -> Type {
+        self.ctx.value_type[value]
     }
 
     /// Changes the destination of all edges with a destination equal to

--- a/crates/module/src/func_body/builder.rs
+++ b/crates/module/src/func_body/builder.rs
@@ -1068,7 +1068,7 @@ impl<'a> FunctionBuilder<'a> {
         // Cut away dead block parameters.
         for block in self.ctx.blocks.indices() {
             let dead_params = &dead_params[block];
-            for (index, &param) in
+            for (index, &old_param) in
                 self.ctx.block_params[block].iter().enumerate()
             {
                 debug_assert!(index < u16::MAX as usize);
@@ -1076,7 +1076,8 @@ impl<'a> FunctionBuilder<'a> {
                 if dead_params.contains(&index) {
                     continue
                 }
-                body.block_params[block].push(param);
+                let new_param = value_replace.get(old_param);
+                body.block_params[block].push(new_param);
             }
         }
         value_replace

--- a/crates/module/src/func_body/instruction.rs
+++ b/crates/module/src/func_body/instruction.rs
@@ -1351,6 +1351,9 @@ impl<'a, 'b: 'a> InstructionBuilder<'a, 'b> {
         debug_assert!(self.builder.ctx.edge_args[edge].is_empty());
         self.builder.ctx.edge_args[edge].extend(args);
         self.builder.ctx.block_edges[destination].push(edge);
+        for &arg in &self.builder.ctx.edge_args[edge] {
+            self.builder.ctx.value_users[arg].insert(ValueUser::Edge(edge));
+        }
         Ok(edge)
     }
 }

--- a/crates/module/src/func_body/mod.rs
+++ b/crates/module/src/func_body/mod.rs
@@ -220,3 +220,9 @@ impl DisplayEdge for FunctionBody {
         Ok(())
     }
 }
+
+impl core::fmt::Display for FunctionBody {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.display_with_indent(f, Indent::default())
+    }
+}

--- a/crates/module/src/func_body/value.rs
+++ b/crates/module/src/func_body/value.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::primitive::Instr;
-use ir::primitive::{Block, Value};
+use ir::primitive::{Block, Edge, Value};
 
 /// A user of an SSA value.
 ///
@@ -22,6 +22,7 @@ use ir::primitive::{Block, Value};
 pub enum ValueUser {
     Instr(Instr),
     Param(Value),
+    Edge(Edge),
 }
 
 /// The definition site of the SSA value.

--- a/crates/wasm/src/function/control/block.rs
+++ b/crates/wasm/src/function/control/block.rs
@@ -29,6 +29,12 @@ pub enum WasmBlockType {
     FuncType(FuncType),
 }
 
+impl From<FuncType> for WasmBlockType {
+    fn from(func_type: FuncType) -> Self {
+        Self::FuncType(func_type)
+    }
+}
+
 impl TryFrom<wasmparser::TypeOrFuncType> for WasmBlockType {
     type Error = Error;
 

--- a/crates/wasm/src/function/control/block.rs
+++ b/crates/wasm/src/function/control/block.rs
@@ -15,7 +15,7 @@
 use crate::Error;
 use core::convert::TryFrom;
 use entity::RawIdx;
-use ir::primitive::{Block, FuncType, Type};
+use ir::primitive::{FuncType, Type};
 use module::ModuleResources;
 
 /// The type of a Wasm block.
@@ -93,64 +93,5 @@ impl WasmBlockType {
                     .outputs()
             }
         }
-    }
-}
-
-/// A Wasm `Block` or `Loop` for Wasm operators to branch to.
-#[derive(Debug, Copy, Clone)]
-pub struct WasmBlock {
-    /// The unique Runwell basic block index of the Wasm block.
-    pub(super) block: Option<Block>,
-    /// The type of the Wasm block.
-    ty: WasmBlockType,
-}
-
-impl WasmBlock {
-    /// Creates a new Wasm block with the given block type.
-    pub fn new<B>(
-        block: B,
-        block_type: wasmparser::TypeOrFuncType,
-    ) -> Result<Self, Error>
-    where
-        B: Into<Option<Block>>,
-    {
-        Ok(Self {
-            block: block.into(),
-            ty: WasmBlockType::try_from(block_type)?,
-        })
-    }
-
-    /// Creates a new Wasm block with the given function type.
-    pub fn with_func_type<B>(block: B, func_type: FuncType) -> Self
-    where
-        B: Into<Option<Block>>,
-    {
-        Self {
-            block: block.into(),
-            ty: WasmBlockType::FuncType(func_type),
-        }
-    }
-
-    /// Returns the associated Runwell block index.
-    pub fn block(&self) -> Option<Block> {
-        self.block
-    }
-
-    /// Returns a slice over the input types of the Wasm block.
-    pub fn inputs<'a, 'b, 'c>(&'a self, res: &'b ModuleResources) -> &'c [Type]
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        self.ty.inputs(res)
-    }
-
-    /// Returns a slice over the output types of the Wasm block.
-    pub fn outputs<'a, 'b, 'c>(&'a self, res: &'b ModuleResources) -> &'c [Type]
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        self.ty.outputs(res)
     }
 }

--- a/crates/wasm/src/function/control/block.rs
+++ b/crates/wasm/src/function/control/block.rs
@@ -1,0 +1,150 @@
+// Copyright 2021 Robin Freyler
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Error;
+use core::convert::TryFrom;
+use entity::RawIdx;
+use ir::primitive::{Block, FuncType, Type};
+use module::ModuleResources;
+
+/// The type of a Wasm block.
+#[derive(Debug, Copy, Clone)]
+pub enum WasmBlockType {
+    /// Block has no inputs and no outputs.
+    Empty,
+    /// Block just returns the inner type and has no inputs.
+    Returns(Type),
+    /// Block is equal to the function type found in the module under the given index.
+    FuncType(FuncType),
+}
+
+impl TryFrom<wasmparser::TypeOrFuncType> for WasmBlockType {
+    type Error = Error;
+
+    fn try_from(
+        block_type: wasmparser::TypeOrFuncType,
+    ) -> Result<Self, Self::Error> {
+        let block_type = match block_type {
+            wasmparser::TypeOrFuncType::Type(
+                wasmparser::Type::EmptyBlockType,
+            ) => Self::Empty,
+            wasmparser::TypeOrFuncType::Type(ty) => {
+                Self::Returns(crate::Type::try_from(ty)?.into_inner())
+            }
+            wasmparser::TypeOrFuncType::FuncType(func_type) => {
+                let func_type = FuncType::from_raw(RawIdx::from_u32(func_type));
+                Self::FuncType(func_type)
+            }
+        };
+        Ok(block_type)
+    }
+}
+
+impl WasmBlockType {
+    /// Returns a slice over the input types of the Wasm block.
+    pub fn inputs<'a, 'b, 'c>(&'a self, res: &'b ModuleResources) -> &'c [Type]
+    where
+        'a: 'c,
+        'b: 'c,
+    {
+        match self {
+            Self::Empty | Self::Returns(_) => &[],
+            Self::FuncType(func_type) => {
+                res.get_type(*func_type)
+                    .unwrap_or_else(|| {
+                        panic!("expect block type due to validation")
+                    })
+                    .inputs()
+            }
+        }
+    }
+
+    /// Returns a slice over the output types of the Wasm block.
+    pub fn outputs<'a, 'b, 'c>(&'a self, res: &'b ModuleResources) -> &'c [Type]
+    where
+        'a: 'c,
+        'b: 'c,
+    {
+        match self {
+            Self::Empty => &[],
+            Self::Returns(return_type) => core::slice::from_ref(return_type),
+            Self::FuncType(func_type) => {
+                res.get_type(*func_type)
+                    .unwrap_or_else(|| {
+                        panic!("expect block type due to validation")
+                    })
+                    .outputs()
+            }
+        }
+    }
+}
+
+/// A Wasm `Block` or `Loop` for Wasm operators to branch to.
+#[derive(Debug, Copy, Clone)]
+pub struct WasmBlock {
+    /// The unique Runwell basic block index of the Wasm block.
+    pub(super) block: Option<Block>,
+    /// The type of the Wasm block.
+    ty: WasmBlockType,
+}
+
+impl WasmBlock {
+    /// Creates a new Wasm block with the given block type.
+    pub fn new<B>(
+        block: B,
+        block_type: wasmparser::TypeOrFuncType,
+    ) -> Result<Self, Error>
+    where
+        B: Into<Option<Block>>,
+    {
+        Ok(Self {
+            block: block.into(),
+            ty: WasmBlockType::try_from(block_type)?,
+        })
+    }
+
+    /// Creates a new Wasm block with the given function type.
+    pub fn with_func_type<B>(block: B, func_type: FuncType) -> Self
+    where
+        B: Into<Option<Block>>,
+    {
+        Self {
+            block: block.into(),
+            ty: WasmBlockType::FuncType(func_type),
+        }
+    }
+
+    /// Returns the associated Runwell block index.
+    pub fn block(&self) -> Option<Block> {
+        self.block
+    }
+
+    /// Returns a slice over the input types of the Wasm block.
+    pub fn inputs<'a, 'b, 'c>(&'a self, res: &'b ModuleResources) -> &'c [Type]
+    where
+        'a: 'c,
+        'b: 'c,
+    {
+        self.ty.inputs(res)
+    }
+
+    /// Returns a slice over the output types of the Wasm block.
+    pub fn outputs<'a, 'b, 'c>(&'a self, res: &'b ModuleResources) -> &'c [Type]
+    where
+        'a: 'c,
+        'b: 'c,
+    {
+        self.ty.outputs(res)
+    }
+}

--- a/crates/wasm/src/function/control/frame.rs
+++ b/crates/wasm/src/function/control/frame.rs
@@ -33,7 +33,7 @@ pub enum ControlFlowFrame {
 /// the expected `End` operator at the end of each Wasm
 /// function body.
 ///
-/// This control frame must not occurre elsewhere on the
+/// This control frame must not occur elsewhere on the
 /// control stack but once at the beginning.
 #[derive(Debug, Copy, Clone)]
 pub struct FunctionBodyFrame {
@@ -152,7 +152,7 @@ impl IfControlFrame {
 /// to `WithElse` when encountering the optional `else` branch.
 /// Sometimes it is possible to infer that an `if` control flow frame requires
 /// an `else` block by inspecting the `if` signature. In these cases,
-/// we pre-allocate the `else` block.
+/// we preallocate the `else` block.
 #[derive(Debug, Copy, Clone)]
 pub enum ElseData {
     /// The `if` does not already have an `else` block.
@@ -170,7 +170,7 @@ pub enum ElseData {
     /// Usually we don't know whether we will hit an `if .. end` or an `if
     /// .. else .. end`, but sometimes we can tell based on the block's type
     /// signature that the signature is not valid if there isn't an `else`.
-    /// In these cases, we pre-allocate the `else` block.
+    /// In these cases, we preallocate the `else` block.
     WithElse {
         /// This is the `else` block.
         else_block: Block,
@@ -280,7 +280,7 @@ impl ControlFlowFrame {
     ///
     /// # Note
     ///
-    /// This flag could be used in some cases to prevent creating of superflous blocks.
+    /// This flag could be used in some cases to prevent creating of superfluous blocks.
     #[allow(dead_code)]
     pub fn exit_is_branched_to(&self) -> bool {
         match self {

--- a/crates/wasm/src/function/control/frame.rs
+++ b/crates/wasm/src/function/control/frame.rs
@@ -180,8 +180,6 @@ impl ControlFlowFrame {
     ///
     /// This returns `None` in case of `Block` control flow frames that
     /// have not yet seen branches to them.
-    ///
-    /// TODO: Decide if we need this API.
     pub fn branch_destination(&self) -> Block {
         match self {
             Self::If(frame) => frame.exit_block,

--- a/crates/wasm/src/function/control/frame.rs
+++ b/crates/wasm/src/function/control/frame.rs
@@ -53,6 +53,22 @@ pub struct BlockControlFrame {
     pub is_branched_to: bool,
 }
 
+impl BlockControlFrame {
+    /// Creates a new `Block` Wasm control frame.
+    pub fn new(
+        block_type: WasmBlockType,
+        original_stack_size: usize,
+        following_block: Block,
+    ) -> Self {
+        Self {
+            block_type,
+            original_stack_size,
+            following_block,
+            is_branched_to: false,
+        }
+    }
+}
+
 /// Control flow frame for a Wasm `Loop` construct.
 #[derive(Debug, Clone)]
 pub struct LoopControlFrame {
@@ -64,6 +80,23 @@ pub struct LoopControlFrame {
     pub loop_exit: Block,
     /// The loop's header block.
     pub loop_header: Block,
+}
+
+impl LoopControlFrame {
+    /// Creates a new `Loop` Wasm control frame.
+    pub fn new(
+        block_type: WasmBlockType,
+        original_stack_size: usize,
+        loop_header: Block,
+        loop_exit: Block,
+    ) -> Self {
+        Self {
+            block_type,
+            original_stack_size,
+            loop_header,
+            loop_exit,
+        }
+    }
 }
 
 /// Control flow frame for a Wasm `If`, `Else`, `End` construct.
@@ -90,6 +123,27 @@ pub struct IfControlFrame {
     pub consequent_ends_reachable: Option<bool>,
     /* Note: no need for `alternative_ends_reachable` because that is just
      * `state.reachable` when we hit the `end` in the `if .. else .. end`. */
+}
+
+impl IfControlFrame {
+    /// Creates a new `If` Wasm control frame.
+    pub fn new(
+        block_type: WasmBlockType,
+        original_stack_size: usize,
+        exit_block: Block,
+        else_data: ElseData,
+        head_is_reachable: bool,
+    ) -> Self {
+        Self {
+            block_type,
+            original_stack_size,
+            exit_block,
+            else_data,
+            head_is_reachable,
+            exit_is_branched_to: false,
+            consequent_ends_reachable: None,
+        }
+    }
 }
 
 /// The optional `else` part of an `if` control flow frame.

--- a/crates/wasm/src/function/control/frame.rs
+++ b/crates/wasm/src/function/control/frame.rs
@@ -244,12 +244,10 @@ impl ControlFlowFrame {
             Self::Block(frame) => frame.is_branched_to = true,
             Self::Loop(frame) => {
                 // A loop exit block is always branched to so we don't store state.
-                ()
             }
             Self::Body(_) => {
                 // Branching to the outermost implicit label (function body)
                 // is similar to a return statement.
-                ()
             }
         }
     }

--- a/crates/wasm/src/function/control/frame.rs
+++ b/crates/wasm/src/function/control/frame.rs
@@ -1,0 +1,177 @@
+// Copyright 2021 Robin Freyler
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::block::WasmBlockType;
+use ir::primitive::Block;
+use module::primitive::Instr;
+
+/// A control flow frame can be a `Block` a `Loop` or an `If` Wasm control instruction.
+#[derive(Debug, Clone)]
+pub enum ControlFlowFrame {
+    If(IfControlFrame),
+    Block(BlockControlFrame),
+    Loop(LoopControlFrame),
+}
+
+/// Control flow frame for a Wasm `Block`.
+#[derive(Debug, Clone)]
+pub struct BlockControlFrame {
+    pub len_inputs: usize,
+    pub len_outputs: usize,
+    pub original_stack_size: usize,
+    pub destination: Option<Block>,
+}
+
+/// Control flow frame for a Wasm `Loop` construct.
+#[derive(Debug, Clone)]
+pub struct LoopControlFrame {
+    pub len_inputs: usize,
+    pub len_outputs: usize,
+    pub original_stack_size: usize,
+    pub loop_exit: Option<Block>,
+    pub loop_header: Block,
+}
+
+/// Control flow frame for a Wasm `If`, `Else`, `End` construct.
+#[derive(Debug, Clone)]
+pub struct IfControlFrame {
+    pub len_inputs: usize,
+    pub len_outputs: usize,
+    pub original_stack_size: usize,
+    pub exit_is_branched_to: bool,
+    pub exit_block: Block,
+    pub else_data: ElseData,
+    pub block_type: WasmBlockType,
+    /// Was the head of the `if` reachable?
+    pub head_is_reachable: bool,
+    /// What was the reachability at the end of the consequent?
+    ///
+    /// This is `None` until we're finished translating the consequent, and
+    /// is set to `Some` either by hitting an `else` when we will begin
+    /// translating the alternative, or by hitting an `end` in which case
+    /// there is no alternative.
+    pub consequent_ends_reachable: Option<bool>,
+    /* Note: no need for `alternative_ends_reachable` because that is just
+     * `state.reachable` when we hit the `end` in the `if .. else .. end`. */
+}
+
+/// The optional `else` part of an `if` control flow frame.
+///
+/// An `if` control flow frame starts with `NoElse` and eventually updates
+/// to `WithElse` when encountering the optional `else` branch.
+/// Sometimes it is possible to infer that an `if` control flow frame requires
+/// an `else` block by inspecting the `if` signature. In these cases,
+/// we pre-allocate the `else` block.
+#[derive(Debug, Copy, Clone)]
+pub enum ElseData {
+    /// The `if` does not already have an `else` block.
+    ///
+    /// This doesn't mean that it will never have an `else`, just that we
+    /// haven't seen it yet.
+    NoElse {
+        /// If we discover that we need an `else` block, this is the jump
+        /// instruction that needs to be fixed up to point to the new `else`
+        /// block rather than the destination block after the `if...end`.
+        branch_instr: Instr,
+    },
+    /// We have already allocated an `else` block.
+    ///
+    /// Usually we don't know whether we will hit an `if .. end` or an `if
+    /// .. else .. end`, but sometimes we can tell based on the block's type
+    /// signature that the signature is not valid if there isn't an `else`.
+    /// In these cases, we pre-allocate the `else` block.
+    WithElse {
+        /// This is the `else` block.
+        else_block: Block,
+    },
+}
+
+/// Helper methods for the control stack objects.
+impl ControlFlowFrame {
+    /// Returns the number of output values of the control flow frame.
+    pub fn len_outputs(&self) -> usize {
+        match self {
+            Self::If(frame) => frame.len_outputs,
+            Self::Block(frame) => frame.len_outputs,
+            Self::Loop(frame) => frame.len_outputs,
+        }
+    }
+
+    /// Returns the number of input values of the control flow frame.
+    pub fn len_inputs(&self) -> usize {
+        match self {
+            Self::If(frame) => frame.len_inputs,
+            Self::Block(frame) => frame.len_inputs,
+            Self::Loop(frame) => frame.len_inputs,
+        }
+    }
+
+    /// Returns the block that follows the control flow frame if any.
+    ///
+    /// # Note
+    ///
+    /// This returns `None` in case of `Block` control flow frames that
+    /// have not yet seen branches to them.
+    pub fn following_code(&self) -> Option<Block> {
+        match self {
+            Self::If(frame) => Some(frame.exit_block),
+            Self::Block(frame) => frame.destination,
+            Self::Loop(frame) => frame.loop_exit,
+        }
+    }
+
+    /// Returns the destination block for branches for the control flow frame if any.
+    ///
+    /// # Note
+    ///
+    /// This returns `None` in case of `Block` control flow frames that
+    /// have not yet seen branches to them.
+    ///
+    /// TODO: Decide if we need this API.
+    pub fn br_destination(&self) -> Option<Block> {
+        match self {
+            Self::If(frame) => Some(frame.exit_block),
+            Self::Block(frame) => frame.destination,
+            Self::Loop(frame) => Some(frame.loop_header),
+        }
+    }
+
+    /// Returns the original value stack size before the control flow frame.
+    ///
+    /// # Note
+    ///
+    /// This is a private helper method. Use `truncate_value_stack_to_else_params()`
+    /// or `truncate_value_stack_to_original_size()` to restore value-stack state.
+    pub fn original_stack_size(&self) -> usize {
+        match self {
+            Self::If(frame) => frame.original_stack_size,
+            Self::Block(frame) => frame.original_stack_size,
+            Self::Loop(frame) => frame.original_stack_size,
+        }
+    }
+
+    /// Returns `true` if the control frame is a Wasm `Loop`.
+    pub fn is_loop(&self) -> bool {
+        matches!(self, Self::Loop(_))
+    }
+
+    /// Returns `true` if there have been branches to the exit block of the control frame.
+    pub fn exit_is_branched_to(&self) -> bool {
+        match self {
+            Self::If(frame) => frame.exit_is_branched_to,
+            Self::Block(frame) => frame.destination.is_some(),
+            Self::Loop(frame) => false,
+        }
+    }
+}

--- a/crates/wasm/src/function/control/frame.rs
+++ b/crates/wasm/src/function/control/frame.rs
@@ -223,6 +223,11 @@ impl ControlFlowFrame {
     }
 
     /// Returns `true` if there have been branches to the exit block of the control frame.
+    ///
+    /// # Note
+    ///
+    /// This flag could be used in some cases to prevent creating of superflous blocks.
+    #[allow(dead_code)]
     pub fn exit_is_branched_to(&self) -> bool {
         match self {
             Self::If(frame) => frame.exit_is_branched_to,

--- a/crates/wasm/src/function/control/mod.rs
+++ b/crates/wasm/src/function/control/mod.rs
@@ -22,6 +22,7 @@ pub use self::{
         BlockControlFrame,
         ControlFlowFrame,
         ElseData,
+        FunctionBodyFrame,
         IfControlFrame,
         LoopControlFrame,
     },

--- a/crates/wasm/src/function/control/mod.rs
+++ b/crates/wasm/src/function/control/mod.rs
@@ -1,0 +1,29 @@
+// Copyright 2021 Robin Freyler
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod block;
+mod frame;
+mod stack;
+
+pub use self::{
+    block::{WasmBlock, WasmBlockType},
+    frame::{
+        BlockControlFrame,
+        ControlFlowFrame,
+        ElseData,
+        IfControlFrame,
+        LoopControlFrame,
+    },
+    stack::ControlFlowStack,
+};

--- a/crates/wasm/src/function/control/mod.rs
+++ b/crates/wasm/src/function/control/mod.rs
@@ -17,7 +17,7 @@ mod frame;
 mod stack;
 
 pub use self::{
-    block::{WasmBlock, WasmBlockType},
+    block::WasmBlockType,
     frame::{
         BlockControlFrame,
         ControlFlowFrame,

--- a/crates/wasm/src/function/control/stack.rs
+++ b/crates/wasm/src/function/control/stack.rs
@@ -34,6 +34,11 @@ pub struct ControlFlowStack {
     frames: Vec<ControlFlowFrame>,
 }
 
+/// Panic message in case an invalid empty control frame stack is encountered.
+const INVALID_EMPTY_CONTROL_STACK: &str =
+    "encountered invalid empty control frame stack but \
+     expected at least the implicit function body label";
+
 impl ControlFlowStack {
     /// Returns `true` if the stack of control flow frames is empty.
     ///
@@ -61,13 +66,18 @@ impl ControlFlowStack {
     }
 
     /// Returns the last control flow frame on the control stack.
-    pub fn last(&self) -> Option<&ControlFlowFrame> {
-        self.frames.last()
+    pub fn first(&self) -> &ControlFlowFrame {
+        self.frames.first().expect(INVALID_EMPTY_CONTROL_STACK)
     }
 
     /// Returns the last control flow frame on the control stack.
-    pub fn last_mut(&mut self) -> Option<&mut ControlFlowFrame> {
-        self.frames.last_mut()
+    pub fn last(&self) -> &ControlFlowFrame {
+        self.frames.last().expect(INVALID_EMPTY_CONTROL_STACK)
+    }
+
+    /// Returns the last control flow frame on the control stack.
+    pub fn last_mut(&mut self) -> &mut ControlFlowFrame {
+        self.frames.last_mut().expect(INVALID_EMPTY_CONTROL_STACK)
     }
 
     /// Returns the nth control flow frame from the back where 0th is the last.

--- a/crates/wasm/src/function/control/stack.rs
+++ b/crates/wasm/src/function/control/stack.rs
@@ -40,16 +40,6 @@ const INVALID_EMPTY_CONTROL_STACK: &str =
      expected at least the implicit function body label";
 
 impl ControlFlowStack {
-    /// Returns `true` if the stack of control flow frames is empty.
-    ///
-    /// # Note
-    ///
-    /// This is usually the case after translating the last `End` Wasm operator
-    /// of a Wasm function.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
     /// Returns the current depth of the stack of control flow frames.
     pub fn len(&self) -> usize {
         self.frames.len()
@@ -71,32 +61,8 @@ impl ControlFlowStack {
     }
 
     /// Returns the last control flow frame on the control stack.
-    pub fn last(&self) -> &ControlFlowFrame {
-        self.frames.last().expect(INVALID_EMPTY_CONTROL_STACK)
-    }
-
-    /// Returns the last control flow frame on the control stack.
     pub fn last_mut(&mut self) -> &mut ControlFlowFrame {
         self.frames.last_mut().expect(INVALID_EMPTY_CONTROL_STACK)
-    }
-
-    /// Returns the nth control flow frame from the back where 0th is the last.
-    ///
-    /// # Errors
-    ///
-    /// If `n` exceeds the length of the stack of control flow frames.
-    pub fn nth_back(
-        &self,
-        n: u32,
-    ) -> Result<&ControlFlowFrame, TranslateError> {
-        self.frames
-            .iter()
-            .rev()
-            .nth_back(n as usize)
-            .ok_or_else(|| {
-                let len = self.frames.len();
-                TranslateError::RelativeDepthExceedsBlockStack { n, len }
-            })
     }
 
     /// Returns the nth control flow frame from the back where 0th is the last.
@@ -114,16 +80,5 @@ impl ControlFlowStack {
             .rev()
             .nth_back(n as usize)
             .ok_or(TranslateError::RelativeDepthExceedsBlockStack { n, len })
-    }
-
-    /// Returns the top most control flow frame.
-    ///
-    /// This is the control flow frame that was put the latest on the stack of frames.
-    ///
-    /// # Errors
-    ///
-    /// If the stack of blocks is empty.
-    pub fn current(&self) -> Result<&ControlFlowFrame, TranslateError> {
-        self.frames.last().ok_or(TranslateError::MissingWasmBlock)
     }
 }

--- a/crates/wasm/src/function/control/stack.rs
+++ b/crates/wasm/src/function/control/stack.rs
@@ -1,0 +1,119 @@
+// Copyright 2021 Robin Freyler
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Copyright 2021 Robin Freyler
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::frame::ControlFlowFrame;
+use crate::TranslateError;
+
+/// The stack of control flow frames.
+#[derive(Debug, Default)]
+pub struct ControlFlowStack {
+    frames: Vec<ControlFlowFrame>,
+}
+
+impl ControlFlowStack {
+    /// Returns `true` if the stack of control flow frames is empty.
+    ///
+    /// # Note
+    ///
+    /// This is usually the case after translating the last `End` Wasm operator
+    /// of a Wasm function.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the current depth of the stack of control flow frames.
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// Pushes a new frame to the stack of control flow frames.
+    pub fn push_frame(&mut self, frame: ControlFlowFrame) {
+        self.frames.push(frame)
+    }
+
+    /// Pops the last frame from the stack of control flow frames.
+    pub fn pop_frame(&mut self) -> Result<ControlFlowFrame, TranslateError> {
+        self.frames.pop().ok_or(TranslateError::MissingWasmBlock)
+    }
+
+    /// Returns the last control flow frame on the control stack.
+    pub fn last(&self) -> Option<&ControlFlowFrame> {
+        self.frames.last()
+    }
+
+    /// Returns the last control flow frame on the control stack.
+    pub fn last_mut(&mut self) -> Option<&mut ControlFlowFrame> {
+        self.frames.last_mut()
+    }
+
+    /// Returns the nth control flow frame from the back where 0th is the last.
+    ///
+    /// # Errors
+    ///
+    /// If `n` exceeds the length of the stack of control flow frames.
+    pub fn nth_back(
+        &self,
+        n: u32,
+    ) -> Result<&ControlFlowFrame, TranslateError> {
+        self.frames
+            .iter()
+            .rev()
+            .nth_back(n as usize)
+            .ok_or_else(|| {
+                let len = self.frames.len();
+                TranslateError::RelativeDepthExceedsBlockStack { n, len }
+            })
+    }
+
+    /// Returns the nth control flow frame from the back where 0th is the last.
+    ///
+    /// # Errors
+    ///
+    /// If `n` exceeds the length of the stack of control flow frames.
+    pub fn nth_back_mut(
+        &mut self,
+        n: u32,
+    ) -> Result<&mut ControlFlowFrame, TranslateError> {
+        let len = self.frames.len();
+        self.frames
+            .iter_mut()
+            .rev()
+            .nth_back(n as usize)
+            .ok_or(TranslateError::RelativeDepthExceedsBlockStack { n, len })
+    }
+
+    /// Returns the top most control flow frame.
+    ///
+    /// This is the control flow frame that was put the latest on the stack of frames.
+    ///
+    /// # Errors
+    ///
+    /// If the stack of blocks is empty.
+    pub fn current(&self) -> Result<&ControlFlowFrame, TranslateError> {
+        self.frames.last().ok_or(TranslateError::MissingWasmBlock)
+    }
+}

--- a/crates/wasm/src/function/control/stack.rs
+++ b/crates/wasm/src/function/control/stack.rs
@@ -108,7 +108,7 @@ impl ControlFlowStack {
         &mut self,
         n: u32,
     ) -> Result<&mut ControlFlowFrame, TranslateError> {
-        let len = self.frames.len();
+        let len = self.len();
         self.frames
             .iter_mut()
             .rev()

--- a/crates/wasm/src/function/mod.rs
+++ b/crates/wasm/src/function/mod.rs
@@ -187,13 +187,11 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
         let block_inputs = block_type.inputs(&self.res);
         debug_assert!(block_inputs.len() <= self.value_stack.len());
         self.control_stack.push_frame(ControlFlowFrame::Block(
-            BlockControlFrame {
+            BlockControlFrame::new(
                 block_type,
-                original_stack_size: self.value_stack.len()
-                    - block_inputs.len(),
-                following_block: block,
-                is_branched_to: false,
-            },
+                self.value_stack.len() - block_inputs.len(),
+                block,
+            ),
         ));
     }
 
@@ -207,13 +205,12 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
         let block_inputs = block_type.inputs(&self.res);
         debug_assert!(block_inputs.len() <= self.value_stack.len());
         self.control_stack.push_frame(ControlFlowFrame::Loop(
-            LoopControlFrame {
+            LoopControlFrame::new(
                 block_type,
-                original_stack_size: self.value_stack.len()
-                    - block_inputs.len(),
+                self.value_stack.len() - block_inputs.len(),
                 loop_header,
                 loop_exit,
-            },
+            ),
         ));
     }
 
@@ -235,17 +232,15 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
             let entry = self.value_stack.last_n(n)?;
             self.value_stack.push(entry.value, entry.ty);
         }
-        self.control_stack
-            .push_frame(ControlFlowFrame::If(IfControlFrame {
-                exit_block: if_exit,
-                else_data,
-                original_stack_size: self.value_stack.len()
-                    - block_inputs.len(),
-                exit_is_branched_to: false,
-                head_is_reachable: self.reachable,
-                consequent_ends_reachable: None,
+        self.control_stack.push_frame(ControlFlowFrame::If(
+            IfControlFrame::new(
                 block_type,
-            }));
+                self.value_stack.len() - block_inputs.len(),
+                if_exit,
+                else_data,
+                self.reachable,
+            ),
+        ));
         Ok(())
     }
 }

--- a/crates/wasm/src/function/operator/control.rs
+++ b/crates/wasm/src/function/operator/control.rs
@@ -12,8 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::super::{blocks::WasmBlock, FunctionBodyTranslator};
-use crate::{Error, TranslateError};
+use super::super::ElseData;
+use ir::{
+    instr::operands::CompareIntOp,
+    primitive::{Block, IntType, Value},
+};
+use module::primitive::Instr;
+
+use super::super::FunctionBodyTranslator;
+use crate::{
+    function::control::{ControlFlowFrame, WasmBlockType},
+    Error,
+    TranslateError,
+};
+use std::convert::TryFrom;
 
 impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
     /// Translate a Wasm `Block` control operator.
@@ -21,8 +33,10 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
         &mut self,
         ty: wasmparser::TypeOrFuncType,
     ) -> Result<(), Error> {
-        let wasm_block = WasmBlock::new(None, ty)?;
-        self.blocks.push_block(wasm_block);
+        let block_type = WasmBlockType::try_from(ty)?;
+        let inputs = block_type.inputs(&self.res);
+        let outputs = block_type.outputs(&self.res);
+        self.push_control_block(inputs.len(), outputs.len());
         Ok(())
     }
 
@@ -32,11 +46,34 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
         ty: wasmparser::TypeOrFuncType,
     ) -> Result<(), Error> {
         let loop_header = self.builder.create_block()?;
-        let wasm_block = WasmBlock::new(loop_header, ty)?;
-        self.blocks.push_block(wasm_block);
+        let block_type = WasmBlockType::try_from(ty)?;
+        let inputs = block_type.inputs(&self.res);
+        let outputs = block_type.outputs(&self.res);
         self.builder.ins()?.br(loop_header, vec![])?;
+        self.push_control_loop(loop_header, inputs.len(), outputs.len());
         self.builder.switch_to_block(loop_header)?;
         Ok(())
+    }
+
+    /// Constructs an if that compares the top most value with zero.
+    fn construct_if_eqz(
+        &mut self,
+        condition: Value,
+        then_block: Block,
+        else_block: Block,
+    ) -> Result<Instr, Error> {
+        let zero = self.builder.ins()?.constant(0)?;
+        let eq = self.builder.ins()?.icmp(
+            IntType::I32,
+            CompareIntOp::Eq,
+            condition,
+            zero,
+        )?;
+        let instr = self
+            .builder
+            .ins()?
+            .if_then_else(eq, then_block, else_block, vec![], vec![])?;
+        Ok(instr)
     }
 
     /// Translate a Wasm `If` control operator.
@@ -44,53 +81,169 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
         &mut self,
         ty: wasmparser::TypeOrFuncType,
     ) -> Result<(), Error> {
-        Err(TranslateError::unimplemented_operator(
-            wasmparser::Operator::If { ty },
-        ))
-        .map_err(Into::into)
+        let condition = self.value_stack.pop1()?;
+        debug_assert_eq!(condition.ty, IntType::I32.into());
+        let block_type = WasmBlockType::try_from(ty)?;
+        let inputs = block_type.inputs(&self.res);
+        let outputs = block_type.outputs(&self.res);
+        let then_block = self.builder.create_block()?;
+        let exit_block = self.builder.create_block()?;
+        let else_data = if inputs == outputs {
+            // It is possible there is no `else` block, so we will only
+            // allocate a block for it when we find the `else`. For now,
+            // if the condition isn't true we jump directly to the
+            // exit block following the whole `if...end`. If we do end
+            // up discovering an `else`, then we will allocate a block for it
+            // and go back and patch the jump.
+            let branch_instr =
+                self.construct_if_eqz(condition.value, then_block, exit_block)?;
+            ElseData::NoElse { branch_instr }
+        } else {
+            // The `if` type signature is not valid without an `else` block,
+            // so we eagerly allocate the `else` block here and make use of it.
+            let else_block = self.builder.create_block()?;
+            let instr =
+                self.construct_if_eqz(condition.value, then_block, else_block)?;
+            self.builder.seal_block(else_block)?;
+            ElseData::WithElse { else_block }
+        };
+        self.builder.seal_block(then_block)?;
+        self.builder.switch_to_block(then_block)?;
+        // Here we append an argument to a block targeted by an argumentless jump instruction.
+        // There are two cases:
+        // - either the If does not have a else clause, in that case: `ty == EmptyBlock`
+        //   and we add nothing;
+        // - or the If has an else clause, in that case the destination of this jump
+        //   instruction will be changed later when we translate the else operator.
+        self.push_control_if(
+            exit_block,
+            else_data,
+            inputs.len(),
+            outputs.len(),
+            block_type,
+        )?;
+        Ok(())
     }
 
     /// Translate a Wasm `Else` control operator.
     pub(super) fn translate_else(&mut self) -> Result<(), Error> {
-        Err(TranslateError::unimplemented_operator(
-            wasmparser::Operator::Else,
-        ))
-        .map_err(Into::into)
+        let parent_if = match self.control_stack.last_mut() {
+            Some(ControlFlowFrame::If(if_frame)) => if_frame,
+            _ => {
+                unreachable!(
+                    "expect to encounter an `if` before encountering an `else`"
+                )
+            }
+        };
+        // We finished the consequent, so record its final
+        // reachability state.
+        debug_assert!(parent_if.consequent_ends_reachable.is_none());
+        parent_if.consequent_ends_reachable = Some(self.reachable);
+        if !parent_if.head_is_reachable {
+            return Ok(())
+        }
+        // We have a branch from the head of the `if` to the `else`.
+        self.reachable = true;
+        // Ensure we have a block for the `else` block (it may have
+        // already been pre-allocated, see `ElseData` for details).
+        let else_block = match parent_if.else_data {
+            ElseData::WithElse { else_block } => else_block,
+            ElseData::NoElse { branch_instr } => {
+                let block_type = parent_if.block_type;
+                let inputs = block_type.inputs(&self.res);
+                let outputs = block_type.outputs(&self.res);
+                debug_assert_eq!(inputs.len(), parent_if.len_outputs);
+                let else_block = self.builder.create_block()?;
+                let exit_block = parent_if.exit_block;
+                self.builder.relink_edge_destination(branch_instr, exit_block, else_block)?;
+                self.builder.seal_block(else_block)?;
+                else_block
+            }
+        };
+        // Finalize the if's `then_block` by branching to the if's exit block.
+        self.builder.ins()?.br(parent_if.exit_block, vec![])?;
+        self.value_stack.pop_n(parent_if.len_outputs)?;
+        // Now switch to the if's `else_block` to continue translation there.
+        //
+        // You might be expecting that we push the parameters for this
+        // `else` block here, something like this:
+        //
+        //     state.pushn(&control_stack_frame.params);
+        //
+        // We don't do that because they are already on the top of the stack
+        // for us: we pushed the parameters twice when we saw the initial
+        // `if` so that we wouldn't have to save the parameters in the
+        // `ControlStackFrame` as another vector allocation.
+        self.builder.switch_to_block(else_block)?;
+        // We don't bother updating the control frame's `ElseData`
+        // to `WithElse` because nothing else will read it.
+        Ok(())
     }
 
     /// Translate a Wasm `End` control operator.
     pub(super) fn translate_end(&mut self) -> Result<(), Error> {
-        let block = self.blocks.pop_block()?;
-        if let Some(runwell_block) = block.block() {
-            let _ = self.builder.seal_block(runwell_block).unwrap_or(());
-        }
-        if self.blocks.is_empty() {
-            // The popped block was the entry block and thus the
-            // `End` operator represents the end of the Wasm function.
-            // Therefore we need to insert a Runwell return statement
-            // returning all values that are still on the stack and
-            // check if they are matching the functions return types.
-            let outputs = self
-                .res
-                .get_func_type(self.func)
-                .unwrap_or_else(|| {
-                    panic!(
-                        "expected function type for {} due to validation",
-                        self.func
-                    )
-                })
-                .outputs();
-            let output_values = self.value_stack.peek_n(outputs.len())?;
-            for (req_type, entry) in
-                outputs.iter().copied().zip(output_values.clone())
-            {
-                assert_eq!(req_type, entry.ty);
+        let frame = self.control_stack.pop_frame()?;
+        let next_block = match frame.following_code() {
+            Some(next_block) => next_block,
+            None => {
+                // The `following_code` is only `None` if there was never
+                // a branch to it or if it is the entry block. Therefore
+                // we can continue staying in the current basic block and
+                // continue translation; OR in case of entry block insert
+                // a final return instruction.
+                if self.control_stack.is_empty() {
+                    // Since the control stack is empty the popped block
+                    // was in fact the entry block.
+                    let outputs = self
+                        .res
+                        .get_func_type(self.func)
+                        .unwrap_or_else(|| {
+                            panic!(
+                            "expected function type for {} due to validation",
+                            self.func
+                        )
+                        })
+                        .outputs();
+                    let output_values =
+                        self.value_stack.peek_n(outputs.len())?.as_slice();
+                    assert!(outputs
+                        .iter()
+                        .copied()
+                        .zip(output_values)
+                        .all(|(lhs, rhs)| lhs == rhs.ty));
+                    self.builder.ins()?.return_values(
+                        output_values.iter().map(|entry| entry.value),
+                    )?;
+                    let original_size = frame.original_stack_size();
+                    self.value_stack.truncate(original_size)?;
+                }
+                return Ok(())
             }
-            self.builder
-                .ins()?
-                .return_values(output_values.map(|entry| entry.value))?;
-            self.value_stack.pop_n(outputs.len())?;
+        };
+        let current = self.builder.current_block()?;
+        if self.builder.is_block_reachable(current)
+        // || self.builder.is_block_touched(current) // same as `!pristine`
+        {
+            self.builder.ins()?.br(next_block, vec![])?;
+            // You might expect that if we just finished an `if` block that
+            // didn't have a corresponding `else` block, then we would clean
+            // up our duplicate set of parameters that we pushed earlier
+            // right here. However, we don't have to explicitly do that,
+            // since we truncate the stack back to the original height
+            // below.
         }
+        self.builder.switch_to_block(next_block)?;
+        self.builder.seal_block(next_block)?;
+        // If it is a loop we also have to seal the body loop block
+        if let ControlFlowFrame::Loop(loop_frame) = &frame {
+            self.builder.seal_block(loop_frame.loop_header)?;
+        }
+        let original_size = frame.original_stack_size();
+        self.value_stack.truncate(original_size)?;
+        // TODO: Push block inputs to value stack.
+        //
+        // Problem: Phi instructions of a block are unordered in comparison
+        //          with block parameters from Cranelift.
         Ok(())
     }
 

--- a/crates/wasm/src/function/operator/control.rs
+++ b/crates/wasm/src/function/operator/control.rs
@@ -76,9 +76,9 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
     ///
     /// # Note
     ///
-    /// Implementation ideas copied over from Cranelift:
+    /// Implementation ideas copied over from Cranelift: [*source*][1]
     ///
-    /// <github.com/bytecodealliance/wasmtime/blob/main/cranelift/wasm/src/code_translator.rs>
+    /// [1]: https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/wasm/src/code_translator.rs
     pub(super) fn translate_block(
         &mut self,
         ty: wasmparser::TypeOrFuncType,
@@ -94,9 +94,9 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
     ///
     /// # Note
     ///
-    /// Implementation ideas copied over from Cranelift:
+    /// Implementation ideas copied over from Cranelift: [*source*][1]
     ///
-    /// <github.com/bytecodealliance/wasmtime/blob/main/cranelift/wasm/src/code_translator.rs>
+    /// [1]: https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/wasm/src/code_translator.rs
     pub(super) fn translate_loop(
         &mut self,
         ty: wasmparser::TypeOrFuncType,
@@ -166,9 +166,9 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
     ///
     /// # Note
     ///
-    /// Implementation ideas copied over from Cranelift:
+    /// Implementation ideas copied over from Cranelift: [*source*][1]
     ///
-    /// <github.com/bytecodealliance/wasmtime/blob/main/cranelift/wasm/src/code_translator.rs>
+    /// [1]: https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/wasm/src/code_translator.rs
     pub(super) fn translate_if(
         &mut self,
         ty: wasmparser::TypeOrFuncType,

--- a/crates/wasm/src/function/operator/control.rs
+++ b/crates/wasm/src/function/operator/control.rs
@@ -12,46 +12,118 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::super::ElseData;
-use ir::{
-    instr::operands::CompareIntOp,
-    primitive::{Block, IntType, Value},
-};
-use module::primitive::Instr;
-
-use super::super::FunctionBodyTranslator;
+use super::super::{ElseData, FunctionBodyTranslator};
 use crate::{
     function::control::{ControlFlowFrame, WasmBlockType},
     Error,
     TranslateError,
 };
-use std::convert::TryFrom;
+use core::convert::TryFrom;
+use ir::{
+    instr::operands::CompareIntOp,
+    primitive::{Block, Const, IntConst, IntType, Type, Value},
+};
+use module::{builder::FunctionBuilder, primitive::Instr};
+
+impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
+    /// Creates a new basic block with the given parameters.
+    fn block_with_params<I>(&mut self, inputs: I) -> Result<Block, Error>
+    where
+        I: IntoIterator<Item = Type>,
+    {
+        Self::block_with_params_explicit(&mut self.builder, inputs)
+    }
+
+    /// Creates a new basic block with the given parameters without `self` receiver.
+    fn block_with_params_explicit<I>(
+        func_builder: &mut FunctionBuilder,
+        inputs: I,
+    ) -> Result<Block, Error>
+    where
+        I: IntoIterator<Item = Type>,
+    {
+        let block = func_builder.create_block()?;
+        for input in inputs {
+            func_builder.create_block_parameter(block, input)?;
+        }
+        Ok(block)
+    }
+
+    /// Pop values from the value stack so that it is left at the state it was
+    /// before this control-flow frame.
+    pub fn truncate_value_stack_to_original_size(
+        &mut self,
+        frame: &ControlFlowFrame,
+    ) -> Result<(), Error> {
+        // The "If" frame pushes its parameters twice, so they're available to the else block
+        // (see also `FuncTranslationState::push_if`).
+        // Yet, the original_stack_size member accounts for them only once, so that the else
+        // block can see the same number of parameters as the consequent block. As a matter of
+        // fact, we need to substract an extra number of parameter values for if blocks.
+        let len_dupe_args = if let ControlFlowFrame::If(if_frame) = frame {
+            if_frame.block_type.inputs(&self.res).len()
+        } else {
+            0
+        };
+        self.value_stack
+            .truncate(frame.original_stack_size() - len_dupe_args)?;
+        Ok(())
+    }
+}
 
 impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
     /// Translate a Wasm `Block` control operator.
+    ///
+    /// # Note
+    ///
+    /// Implementation ideas copied over from Cranelift:
+    ///
+    /// <github.com/bytecodealliance/wasmtime/blob/main/cranelift/wasm/src/code_translator.rs>
     pub(super) fn translate_block(
         &mut self,
         ty: wasmparser::TypeOrFuncType,
     ) -> Result<(), Error> {
         let block_type = WasmBlockType::try_from(ty)?;
         let inputs = block_type.inputs(&self.res);
-        let outputs = block_type.outputs(&self.res);
-        self.push_control_block(inputs.len(), outputs.len());
+        let block = self.block_with_params(inputs.iter().copied())?;
+        self.push_control_block(block, block_type);
         Ok(())
     }
 
     /// Translate a Wasm `Loop` control operator.
+    ///
+    /// # Note
+    ///
+    /// Implementation ideas copied over from Cranelift:
+    ///
+    /// <github.com/bytecodealliance/wasmtime/blob/main/cranelift/wasm/src/code_translator.rs>
     pub(super) fn translate_loop(
         &mut self,
         ty: wasmparser::TypeOrFuncType,
     ) -> Result<(), Error> {
-        let loop_header = self.builder.create_block()?;
         let block_type = WasmBlockType::try_from(ty)?;
         let inputs = block_type.inputs(&self.res);
         let outputs = block_type.outputs(&self.res);
-        self.builder.ins()?.br(loop_header, vec![])?;
-        self.push_control_loop(loop_header, inputs.len(), outputs.len());
-        self.builder.switch_to_block(loop_header)?;
+        let loop_head = self.block_with_params(inputs.iter().copied())?;
+        let loop_exit = self.block_with_params(outputs.iter().copied())?;
+        let args = self.value_stack.peek_n(inputs.len())?;
+        self.builder
+            .ins()?
+            .br(loop_head, args.map(|entry| entry.value))?;
+        self.push_control_loop(loop_head, loop_exit, block_type);
+
+        // Pop the initial `Block` actuals and replace them with the `Block`'s
+        // params since control flow joins at the top of the loop.
+        self.value_stack.pop_n(inputs.len())?;
+        self.value_stack.extend(
+            self.builder
+                .block_parameters(loop_head)
+                .iter()
+                .copied()
+                .zip(inputs.iter().copied()),
+        );
+
+        self.builder.switch_to_block(loop_head)?;
         Ok(())
     }
 
@@ -61,33 +133,55 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
         condition: Value,
         then_block: Block,
         else_block: Block,
+        len_then_args: usize,
+        len_else_args: usize,
     ) -> Result<Instr, Error> {
-        let zero = self.builder.ins()?.constant(0)?;
+        let zero =
+            self.builder.ins()?.constant(Const::Int(IntConst::I32(0)))?;
+        debug_assert_eq!(
+            self.builder.value_type(condition),
+            IntType::I32.into()
+        );
         let eq = self.builder.ins()?.icmp(
             IntType::I32,
             CompareIntOp::Eq,
             condition,
             zero,
         )?;
-        let instr = self
-            .builder
-            .ins()?
-            .if_then_else(eq, then_block, else_block, vec![], vec![])?;
+        let instr = self.builder.ins()?.if_then_else(
+            eq,
+            then_block,
+            else_block,
+            self.value_stack
+                .peek_n(len_then_args)?
+                .map(|entry| entry.value),
+            self.value_stack
+                .peek_n(len_else_args)?
+                .map(|entry| entry.value),
+        )?;
         Ok(instr)
     }
 
     /// Translate a Wasm `If` control operator.
+    ///
+    /// # Note
+    ///
+    /// Implementation ideas copied over from Cranelift:
+    ///
+    /// <github.com/bytecodealliance/wasmtime/blob/main/cranelift/wasm/src/code_translator.rs>
     pub(super) fn translate_if(
         &mut self,
         ty: wasmparser::TypeOrFuncType,
     ) -> Result<(), Error> {
         let condition = self.value_stack.pop1()?;
         debug_assert_eq!(condition.ty, IntType::I32.into());
+
         let block_type = WasmBlockType::try_from(ty)?;
         let inputs = block_type.inputs(&self.res);
         let outputs = block_type.outputs(&self.res);
+
         let then_block = self.builder.create_block()?;
-        let exit_block = self.builder.create_block()?;
+        let exit_block = self.block_with_params(outputs.iter().copied())?;
         let else_data = if inputs == outputs {
             // It is possible there is no `else` block, so we will only
             // allocate a block for it when we find the `else`. For now,
@@ -95,74 +189,97 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
             // exit block following the whole `if...end`. If we do end
             // up discovering an `else`, then we will allocate a block for it
             // and go back and patch the jump.
-            let branch_instr =
-                self.construct_if_eqz(condition.value, then_block, exit_block)?;
+            let branch_instr = self.construct_if_eqz(
+                condition.value,
+                then_block,
+                exit_block,
+                0,
+                inputs.len(),
+            )?;
             ElseData::NoElse { branch_instr }
         } else {
             // The `if` type signature is not valid without an `else` block,
-            // so we eagerly allocate the `else` block here and make use of it.
-            let else_block = self.builder.create_block()?;
-            let instr =
-                self.construct_if_eqz(condition.value, then_block, else_block)?;
+            // so we eagerly allocate the `else` block here.
+            let else_block = self.block_with_params(inputs.iter().copied())?;
+            let branch_instr = self.construct_if_eqz(
+                condition.value,
+                then_block,
+                else_block,
+                0,
+                inputs.len(),
+            )?;
             self.builder.seal_block(else_block)?;
             ElseData::WithElse { else_block }
         };
         self.builder.seal_block(then_block)?;
         self.builder.switch_to_block(then_block)?;
-        // Here we append an argument to a block targeted by an argumentless jump instruction.
-        // There are two cases:
-        // - either the If does not have a else clause, in that case: `ty == EmptyBlock`
+
+        // Here we append an argument to a Block targeted by an argumentless jump instruction
+        // But in fact there are two cases:
+        // - either the If does not have a Else clause, in that case ty = EmptyBlock
         //   and we add nothing;
-        // - or the If has an else clause, in that case the destination of this jump
-        //   instruction will be changed later when we translate the else operator.
-        self.push_control_if(
-            exit_block,
-            else_data,
-            inputs.len(),
-            outputs.len(),
-            block_type,
-        )?;
+        // - either the If have an Else clause, in that case the destination of this jump
+        //   instruction will be changed later when we translate the Else operator.
+        self.push_control_if(exit_block, else_data, block_type)?;
         Ok(())
     }
 
     /// Translate a Wasm `Else` control operator.
     pub(super) fn translate_else(&mut self) -> Result<(), Error> {
-        let parent_if = match self.control_stack.last_mut() {
-            Some(ControlFlowFrame::If(if_frame)) => if_frame,
-            _ => {
-                unreachable!(
-                    "expect to encounter an `if` before encountering an `else`"
-                )
-            }
+        let frame = match self.control_stack.last_mut() {
+            ControlFlowFrame::If(frame) => frame,
+            _ => unreachable!("missing `if` frame upon encountering `else`"),
         };
-        // We finished the consequent, so record its final
-        // reachability state.
-        debug_assert!(parent_if.consequent_ends_reachable.is_none());
-        parent_if.consequent_ends_reachable = Some(self.reachable);
-        if !parent_if.head_is_reachable {
+        // We just finished the `then_block` (consequent), so record
+        // its final reachability state.
+        debug_assert!(frame.consequent_ends_reachable.is_none());
+        frame.consequent_ends_reachable = Some(self.reachable);
+        if !frame.head_is_reachable {
+            // If the `if` was not reachable we have nothing to do
+            // in the `else_block` either.
             return Ok(())
         }
         // We have a branch from the head of the `if` to the `else`.
         self.reachable = true;
         // Ensure we have a block for the `else` block (it may have
         // already been pre-allocated, see `ElseData` for details).
-        let else_block = match parent_if.else_data {
-            ElseData::WithElse { else_block } => else_block,
+        let else_block = match frame.else_data {
+            ElseData::WithElse { else_block } => {
+                let outputs = frame.block_type.outputs(&self.res);
+                let exit_block = frame.exit_block;
+                self.builder.ins()?.br(
+                    exit_block,
+                    self.value_stack
+                        .pop_n(outputs.len())?
+                        .map(|entry| entry.value),
+                )?;
+                else_block
+            }
             ElseData::NoElse { branch_instr } => {
-                let block_type = parent_if.block_type;
+                let block_type = frame.block_type;
                 let inputs = block_type.inputs(&self.res);
                 let outputs = block_type.outputs(&self.res);
-                debug_assert_eq!(inputs.len(), parent_if.len_outputs);
-                let else_block = self.builder.create_block()?;
-                let exit_block = parent_if.exit_block;
-                self.builder.relink_edge_destination(branch_instr, exit_block, else_block)?;
+                debug_assert_eq!(inputs.len(), outputs.len());
+                let else_block = Self::block_with_params_explicit(
+                    &mut self.builder,
+                    inputs.iter().copied(),
+                )?;
+                let exit_block = frame.exit_block;
+                self.builder.ins()?.br(
+                    exit_block,
+                    self.value_stack
+                        .pop_n(inputs.len())?
+                        .map(|entry| entry.value),
+                )?;
+                self.builder.relink_edge_destination(
+                    branch_instr,
+                    exit_block,
+                    else_block,
+                )?;
                 self.builder.seal_block(else_block)?;
                 else_block
             }
         };
-        // Finalize the if's `then_block` by branching to the if's exit block.
-        self.builder.ins()?.br(parent_if.exit_block, vec![])?;
-        self.value_stack.pop_n(parent_if.len_outputs)?;
         // Now switch to the if's `else_block` to continue translation there.
         //
         // You might be expecting that we push the parameters for this
@@ -183,48 +300,36 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
     /// Translate a Wasm `End` control operator.
     pub(super) fn translate_end(&mut self) -> Result<(), Error> {
         let frame = self.control_stack.pop_frame()?;
-        let next_block = match frame.following_code() {
-            Some(next_block) => next_block,
-            None => {
-                // The `following_code` is only `None` if there was never
-                // a branch to it or if it is the entry block. Therefore
-                // we can continue staying in the current basic block and
-                // continue translation; OR in case of entry block insert
-                // a final return instruction.
-                if self.control_stack.is_empty() {
-                    // Since the control stack is empty the popped block
-                    // was in fact the entry block.
-                    let outputs = self
-                        .res
-                        .get_func_type(self.func)
-                        .unwrap_or_else(|| {
-                            panic!(
-                            "expected function type for {} due to validation",
-                            self.func
-                        )
-                        })
-                        .outputs();
-                    let output_values =
-                        self.value_stack.peek_n(outputs.len())?.as_slice();
-                    assert!(outputs
-                        .iter()
-                        .copied()
-                        .zip(output_values)
-                        .all(|(lhs, rhs)| lhs == rhs.ty));
-                    self.builder.ins()?.return_values(
-                        output_values.iter().map(|entry| entry.value),
-                    )?;
-                    let original_size = frame.original_stack_size();
-                    self.value_stack.truncate(original_size)?;
-                }
+        if let ControlFlowFrame::Body(body_frame) = frame {
+            let current = self.builder.current_block()?;
+            if !self.reachable || !self.builder.is_block_reachable(current) {
+                // We won't generate a return instruction if the code at
+                // this point is unreachable since the value stack could
+                // be different from our expectations.
                 return Ok(())
             }
-        };
+            // We just encountered the final `End` operator.
+            // So we put a return instruction at the end of the function body.
+            let len_stack = self.value_stack.len();
+            // debug_assert_eq!(
+            //     len_stack,
+            //     body_frame.block_type.outputs(&self.res).len()
+            // );
+            let return_values =
+                self.value_stack.pop_n(len_stack)?.map(|entry| entry.value);
+            self.builder.ins()?.return_values(return_values)?;
+            return Ok(())
+        }
+        let next_block = frame.following_code();
         let current = self.builder.current_block()?;
         if self.builder.is_block_reachable(current)
-        // || self.builder.is_block_touched(current) // same as `!pristine`
+        // || !builder.is_pristine()
         {
-            self.builder.ins()?.br(next_block, vec![])?;
+            let len_outputs = frame.outputs(&self.res).len();
+            let output_args = self.value_stack.peek_n(len_outputs)?;
+            self.builder
+                .ins()?
+                .br(next_block, output_args.map(|entry| entry.value))?;
             // You might expect that if we just finished an `if` block that
             // didn't have a corresponding `else` block, then we would clean
             // up our duplicate set of parameters that we pushed earlier
@@ -234,16 +339,23 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
         }
         self.builder.switch_to_block(next_block)?;
         self.builder.seal_block(next_block)?;
+
         // If it is a loop we also have to seal the body loop block
         if let ControlFlowFrame::Loop(loop_frame) = &frame {
             self.builder.seal_block(loop_frame.loop_header)?;
         }
-        let original_size = frame.original_stack_size();
-        self.value_stack.truncate(original_size)?;
-        // TODO: Push block inputs to value stack.
-        //
-        // Problem: Phi instructions of a block are unordered in comparison
-        //          with block parameters from Cranelift.
+
+        self.truncate_value_stack_to_original_size(&frame)?;
+        let Self {
+            value_stack,
+            ref builder,
+            ..
+        } = self;
+        let next_block_params = builder
+            .block_parameters(next_block)
+            .iter()
+            .map(|&value| (value, builder.value_type(value)));
+        value_stack.extend(next_block_params);
         Ok(())
     }
 
@@ -252,10 +364,27 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
         &mut self,
         relative_depth: u32,
     ) -> Result<(), Error> {
-        Err(TranslateError::unimplemented_operator(
-            wasmparser::Operator::Br { relative_depth },
-        ))
-        .map_err(Into::into)
+        let frame = self.control_stack.nth_back_mut(relative_depth)?;
+        if frame.is_func_body() {
+            // Branching to the implicit function body label is equal to a return.
+            return self.translate_return()
+        }
+        // We signal that all the code that follows until the next `End` is unreachable.
+        frame.set_branched_to_exit();
+        let len_return_values = if frame.is_loop() {
+            frame.inputs(&self.res).len()
+        } else {
+            frame.outputs(&self.res).len()
+        };
+        let destination_args = self
+            .value_stack
+            .pop_n(len_return_values)?
+            .map(|entry| entry.value);
+        self.builder
+            .ins()?
+            .br(frame.branch_destination(), destination_args)?;
+        self.reachable = false;
+        Ok(())
     }
 
     /// Translate a Wasm `BrIf` control operator.
@@ -282,9 +411,14 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
 
     /// Translate a Wasm `Return` control operator.
     pub(super) fn translate_return(&mut self) -> Result<(), Error> {
-        Err(TranslateError::unimplemented_operator(
-            wasmparser::Operator::Return,
-        ))
-        .map_err(Into::into)
+        let frame = &mut self.control_stack.first();
+        let outputs = frame.outputs(&self.res);
+        let return_args = self
+            .value_stack
+            .pop_n(outputs.len())?
+            .map(|entry| entry.value);
+        self.builder.ins()?.return_values(return_args)?;
+        self.reachable = false;
+        Ok(())
     }
 }

--- a/crates/wasm/src/function/operator/mod.rs
+++ b/crates/wasm/src/function/operator/mod.rs
@@ -53,6 +53,7 @@ impl<'a, 'b> FunctionBodyTranslator<'a, 'b> {
         match op {
             Op::Unreachable => {
                 self.builder.ins()?.unreachable()?;
+                self.reachable = false;
             }
             Op::Nop => { /* Deliberately do nothing. */ }
             Op::Block { ty } => self.translate_block(ty)?,

--- a/crates/wasm/src/function/stack.rs
+++ b/crates/wasm/src/function/stack.rs
@@ -36,6 +36,16 @@ impl ValueStack {
         self.stack.push(ValueEntry { value, ty });
     }
 
+    /// Extends the value stack by the given iterator of pairs of values and types.
+    pub fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = (Value, Type)>,
+    {
+        self.stack.extend(
+            iter.into_iter().map(|(value, ty)| ValueEntry { value, ty }),
+        )
+    }
+
     /// Pops a value from the stack or returns an error if not possible.
     fn pop_impl(
         &mut self,

--- a/crates/wasm/tests/spec.rs
+++ b/crates/wasm/tests/spec.rs
@@ -155,6 +155,6 @@ fn parse_works() {
     );
     // We currently expect not to pass the entire Wasm spec testsuite since our
     // Wasm to Runwell conversion routines are not yet fully implemented.
-    let expected_failures = 86;
+    let expected_failures = 78;
     assert_eq!(len_failed, expected_failures);
 }


### PR DESCRIPTION
Implemented control flow operators include:

- `Block`
- `Loop`
- `If` & `Else`
- `End`
- `Br`
- `Return`

To be implemented Wasm control flow operators:

- `BrTable`
- `BrIf`